### PR TITLE
fix django naive datetime warnings

### DIFF
--- a/broadcasts/managers.py
+++ b/broadcasts/managers.py
@@ -1,7 +1,6 @@
-from datetime import datetime
-
 from django.db import models
 from django.db.models import Q
+from django.utils import timezone
 
 
 class BroadcastManager(models.Manager):
@@ -15,8 +14,8 @@ class BroadcastManager(models.Manager):
 
     def current(self):
         """Return only current and active messages"""
-        return self.active().filter(end_time__gte=datetime.now()).filter(
-            Q(Q(start_time__lte=datetime.now()) | Q(start_time=None)))
+        return self.active().filter(end_time__gte=timezone.now()).filter(
+            Q(Q(start_time__lte=timezone.now()) | Q(start_time=None)))
 
     def latest(self):
         """Return the broadcast message to display"""


### PR DESCRIPTION
Django uses the `warnings` lib to log a warning message on every page load due to the use of naive datetimes in the `BroadcastManager`. This PR replaces the uses of `datetime.now()` with Django's `timezone.now()`, which makes use of the timezone configured in the Django settings module(s). 